### PR TITLE
nya: unocoin withdrawn

### DIFF
--- a/nya/entities.json
+++ b/nya/entities.json
@@ -307,10 +307,11 @@
     },
     {
         "entity": "Unocoin (India)",
-        "status": 2,
+        "status": 1,
         "dcg": true,
         "twitter": "unocoin",
-        "email": "support@unocoin.com"
+        "email": "support@unocoin.com",
+        "withdrawnUrl": "https://news.unocoin.com/?p=796"
     },
     {
         "entity": "Veem (United States)",


### PR DESCRIPTION
https://news.unocoin.com/?p=796 Specifically the update on 24th October 2017 emphasizes that BTC will be used for trading and B2X is only available for withdrawal:

> We will be treating the legacy bitcoin blockchain (present bitcoin blockchain that is supporting 1MB blocks) as the bitcoin (BTC) and will be allowed to trade for INR. The forked coin which is the result of the SegWit2X implementation will be treated as the minority chain coin (B2X). We will be allowing the B2X to be withdrawn by our customers after the split as per the timelines above.