### PR TITLE
bitso announcement

### DIFF
--- a/nya/entities.json
+++ b/nya/entities.json
@@ -81,10 +81,11 @@
   },
   {
     "entity": "Bitso (Mexico)",
-    "status": 2,
+    "status": 1,
     "dcg": true,
     "bca": true,
     "twitter": "bitso"
+    "withdrawnUrl": "https://lists.linuxfoundation.org/pipermail/bitcoin-segwit2x/2017-November/000632.html"
   },
   {
     "entity": "Bitwala (Germany)",


### PR DESCRIPTION
Quote from the post:

"Whether this failure is the fault of some loudmouths in twitter, some trolls in Reddit, or very opinionated and principled engineers and scientists is irrelevant. What's relevant is that NYA has failed to bring the community together and provide a safe mechanism to upgrade Bitcoin as it had intended to do.

I might be stupidly naive or I might just be figuring how decentralized consensus mechanisms work (like many of you, I'd assume), but when asked about signing the NYA I definitely didn't agree to it in order to further divide and cause mayhem, which is what NYA has achieved.

I ultimately think this is about users. We had ZERO users asking us to keep support for the now dead pre-Byzantium ETH chain. We have tons of users asking us to keep support for their "core" BTC."

Also see here: https://www.reddit.com/r/Bitcoin/comments/7aibas/i_know_no2x_is_old_news_by_now_and_we_dont_care/