### PR TITLE
tweak performance

### DIFF
--- a/charts/index.html
+++ b/charts/index.html
@@ -50,6 +50,7 @@ a {
 
 <div class="period">
 <a href="#" onclick="drawCharts(0);">since activation</a> |
+<a href="#" onclick="drawCharts(30 * 24 * 6);">last 30 days</a> |
 <a href="#" onclick="drawCharts(7 * 24 * 6);">last week</a> |
 <a href="#" onclick="drawCharts(3 * 24 * 6);">last 3 days</a> |
 <a href="#" onclick="drawCharts(1 * 24 * 6);">last day</a>


### PR DESCRIPTION
while poking around, I noticed a lot of calls to `slice`, which meant to me that many of the `map` operations were being done on the entire set of block data, when they only need to be performed against a subset.

I also noticed a lot of calls to `map` so I got rid of most of them and replaced them with a single call to `reduce` keeping track of all the info necessary to produce the charts.

Finally I added an option to the page for "last 30 days", just because i personally want to see it.